### PR TITLE
Composer upgrades for `lunarphp/meilisearch`

### DIFF
--- a/search/meilisearch/composer.json
+++ b/search/meilisearch/composer.json
@@ -13,8 +13,8 @@
   "require": {
       "php": "^8.0",
       "lunarphp/lunar": "^0.7",
-      "meilisearch/meilisearch-php": "^0.26.1",
-      "laravel/scout": "^9.4"
+      "meilisearch/meilisearch-php": "^1.4",
+      "laravel/scout": "^9.4|^10.0"
   },
   "require-dev": {
       "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Upgrade `meilisearch/meilisearch-php` and `laravel/scout` dependencies to avoid version conflicts with recent laravel and lunar versions. 