### PR TITLE
Fix string deprecation warning in WebhookController.php

### DIFF
--- a/payment/stripe/src/Http/Controllers/WebhookController.php
+++ b/payment/stripe/src/Http/Controllers/WebhookController.php
@@ -44,7 +44,7 @@ final class WebhookController extends Controller
 
         if (! $cart) {
             Log::error(
-                $error = "Unable to find cart with intent ${paymentIntent}"
+                $error = "Unable to find cart with intent {$paymentIntent}"
             );
 
             return response(status: 400)->json([


### PR DESCRIPTION
Just a fix for the string deprecation warning when using PHP 8.2 or above.